### PR TITLE
Fix: Consider subtile URL with params when getting the file extension

### DIFF
--- a/lib/utils/subtitle-parser.ts
+++ b/lib/utils/subtitle-parser.ts
@@ -8,7 +8,8 @@ import timeToSeconds from './time-to-seconds'
 const subtitleParser = async (subitleUrl: string): Promise<Subtitle[]> => {
   const { data: subtitleData } = await axios.get(subitleUrl)
 
-  const subtitleType = subitleUrl.split('.')[subitleUrl.split('.').length - 1]
+  const urlWithoutParams = subitleUrl.split('?')[0];
+  const subtitleType = urlWithoutParams.split('.').pop();
 
   const result: Subtitle[] = []
 


### PR DESCRIPTION
When the application passes a subtitle URL with params the package is not able to recognize the subtitle type. The URL params is very common in commercial applications since the server may accept requests only with authorization toke inside the URL params. this fix should be able to take the params in consideration and properly extract the subtitle type from the URL.